### PR TITLE
feat: align workflow secrets and add no failure flag for SAM

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -455,8 +455,8 @@ module.exports = class extends Generator {
                 'In order for the S3 deploy process to work with GitHub Actions, some env variables need to be set:'
             );
             outputStrings.push(
-                '* `AWS_KEY` - AWS key for account with access to manage resources in AWS\n' +
-                    '* `AWS_SECRET` - AWS secret for account with access to manage resources in AWS\n' +
+                '* `AWS_ACCESS_KEY_ID` - AWS key for account with access to manage resources in AWS\n' +
+                    '* `AWS_SECRET_ACCESS_KEY` - AWS secret for account with access to manage resources in AWS\n' +
                     '* `SLACK_WEBHOOK` - Slack Webhook key for Slack org'
             );
 

--- a/generators/app/templates/.github/workflows/s3_release.yml
+++ b/generators/app/templates/.github/workflows/s3_release.yml
@@ -41,8 +41,8 @@ jobs:
                   args: --follow-symlinks --delete
               env:
                   AWS_S3_BUCKET: '<<s3-bucket-base-name>>-dev'
-                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY }}
-                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET }}
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_REGION: 'us-east-1'
                   SOURCE_DIR: './build'
             - name: Slack Notification
@@ -79,8 +79,8 @@ jobs:
                   args: --follow-symlinks --delete
               env:
                   AWS_S3_BUCKET: '<<s3-bucket-base-name>>-test'
-                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY }}
-                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET }}
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_REGION: 'us-east-1'
                   SOURCE_DIR: './build'
             - name: Slack Notification
@@ -117,8 +117,8 @@ jobs:
                   args: --follow-symlinks --delete
               env:
                   AWS_S3_BUCKET: '<<s3-bucket-base-name>>-app'
-                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY }}
-                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET }}
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_REGION: 'us-east-1'
                   SOURCE_DIR: './build'
             - name: Slack Notification

--- a/generators/app/templates/.github/workflows/sam_deploy.yml
+++ b/generators/app/templates/.github/workflows/sam_deploy.yml
@@ -52,7 +52,7 @@ jobs:
             - name: SAM Deploy
               uses: TractorZoom/sam-cli-action@master
               with:
-                  sam_command: 'deploy --parameter-overrides ENV=Test --stack-name <<stack-base-name>>-test'
+                  sam_command: 'deploy --no-fail-on-empty-changeset --parameter-overrides ENV=Test --stack-name <<stack-base-name>>-test'
               env:
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -75,7 +75,7 @@ jobs:
             - name: SAM deploy
               uses: TractorZoom/sam-cli-action@master
               with:
-                  sam_command: 'deploy --parameter-overrides ENV=Prod --stack-name <<stack-base-name>>-prod'
+                  sam_command: 'deploy --no-fail-on-empty-changeset --parameter-overrides ENV=Prod --stack-name <<stack-base-name>>-prod'
               env:
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Description
###Feature
Add `--no-fail-on-empty-changeset` on SAM deploys

### Chore
Align workflow secrets for AWS access

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally