### PR TITLE
feat: limit aws sdk package updating too frequently

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -71,6 +71,12 @@ const addRenovateConfiguration = (context) => {
         major: {
             automerge: false,
         },
+        packageRules: [
+            {
+                packageNames: ['aws-sdk'],
+                schedule: ['after 9pm on sunday'],
+            },
+        ],
         prConcurrentLimit: 5,
         prHourlyLimit: 10,
         semanticCommitType: 'fix',


### PR DESCRIPTION
## Description
### Feature
Limit Renovate update frequency for `aws-sdk`

for https://github.com/TractorZoom/generator-dev-tools/issues/49

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally